### PR TITLE
cloudflare.sh: Fix the script and add verification

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,6 +172,8 @@ and `ORIG_SPF` variables which stand for the target SPF domain
 (e.g. `spf-orig.spf-tools.eu.org`) in order to use `runspftools.sh`
 without modifying the script.
 
+The script if written against v4 of https://api.cloudflare.com/
+
 The only needed permissions for a custom API token are:
   - Zone.Zone: Read
   - Zone.DNS: Edit

--- a/README.md
+++ b/README.md
@@ -172,6 +172,10 @@ and `ORIG_SPF` variables which stand for the target SPF domain
 (e.g. `spf-orig.spf-tools.eu.org`) in order to use `runspftools.sh`
 without modifying the script.
 
+The only needed permissions for a custom API token are:
+  - Zone.Zone: Read
+  - Zone.DNS: Edit
+
 Usage:
 
     ./despf.sh | ./normalize.sh | ./simplify.sh | ./mkblocks.sh 2>&1 \


### PR DESCRIPTION
Fixes https://github.com/spf-tools/spf-tools/issues/164

Adds support for basic token verification: If run with

    ./cloudflare.sh verify

The only needed permissions for a custom API token are:
  - Zone.Zone: Read
  - Zone.DNS: Edit