### PR TITLE
cloudflare.sh: Get rid of EMAIL

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,7 +165,7 @@ Script to update pre-existing TXT SPF records for a domain according
 to the input in DNS zone format using CloudFlare's API.
 
 To use this script, file `.spf-toolsrc` in `$HOME` directory should
-contain `TOKEN` and `EMAIL` variable definitions which are then used
+contain `TOKEN` variable definition which is then used
 to connect to CloudFlare API. The file should also contain `DOMAIN`
 and `ORIG_SPF` variables which stand for the target SPF domain
 (e.g. `spf-tools.eu.org`) and original SPF record with includes

--- a/cloudflare.sh
+++ b/cloudflare.sh
@@ -51,11 +51,10 @@ apicmd() {
     "$@"
 }
 
-# Read TOKEN and EMAIL
+# Read TOKEN
 test -r $SPFTRC && . $SPFTRC
 
 test -n "$TOKEN" || { echo "TOKEN not set! Exiting." >&2; exit 1; }
-test -n "$EMAIL" || { echo "EMAIL not set! Exiting.">&2; exit 1; }
 
 test "$1" = "verify" && {
 	apicmd GET "/user/tokens/verify"


### PR DESCRIPTION
Since Auth Bearer the EMAIL variable is not used at all
so the script should not check it exists. Updated README.md
as well.