### PR TITLE
Jcbf/issue 163

### DIFF
--- a/README.md
+++ b/README.md
@@ -200,7 +200,7 @@ Dependencies: [jq](https://stedolan.github.io/jq/),
 
   Available options:
     -t TTL                     set Time To Live for DNS records
-    -a TXT RECORD              set aditional TXT record to domain (can use multiples times)
+    -a TXT RECORD              set aditional TXT record to domain (can be used multiple times)
 
   Default values:
     TTL = 300

--- a/README.md
+++ b/README.md
@@ -193,6 +193,18 @@ Dependencies: [jq](https://stedolan.github.io/jq/),
 [sed](https://www.gnu.org/software/sed/),
 [grep](https://www.gnu.org/software/grep/)
 
+```
+ Usage: route53.sh [OPTION]... [HOSTED_ZONE_ID]
+  Script to update pre-existing TXT SPF records for
+  a domain according to the input in DNS zone format.
+
+  Available options:
+    -t TTL                     set Time To Live for DNS records
+    -a TXT RECORD              set aditional TXT record to domain (can use multiples times)
+
+  Default values:
+    TTL = 300
+```
 Script to update pre-existing TXT SPF records for a domain according
 to the input in DNS zone format.
 
@@ -201,11 +213,10 @@ environment variables: `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY`
 (find more details in [Configuring the AWS CLI](http://docs.aws.amazon.com/cli/latest/userguide/cli-chap-getting-started.html#cli-environment)
 documentation.
 
-
-Usage:
+Example:
 
     ./despf.sh | ./simplify.sh | ./mkblocks.sh | \
-      ./route53.sh <hosted_zone_id>
+      ./route53.sh -a "google-site-verification=deadbeef" DEADBEEF
 
 
 ### iprange.sh

--- a/route53.sh
+++ b/route53.sh
@@ -53,7 +53,7 @@ usage() {
 
   Available options:
     -t TTL                     set Time To Live for DNS records
-    -a TXT RECORD              set aditional TXT record to domain (can use multiples times)
+    -a TXT RECORD              set aditional TXT record to domain (can be used multiple times)
 
   Default values:
     TTL = $ttl


### PR DESCRIPTION
New -a can be used to specify  additional TXT records

Example:
```
(...)|  ./route53.sh -a "google-stuf=asdasda" -a "microsoft-yada=bla" SKDU638HFD3
``` 
Record, limited to one, can also be specified in the environment variable SPFT_ADDITIONAL_TXT and from SPFTRC file. 