### PR TITLE
Remove Shippable CI

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,6 @@
 [![Codeship badge][codeship-img]][codeship]
 [![Travis-CI badge][travis-img]][travis]
 [![SemaphoreCI badge][semaphore-img]][semaphore]
-[![Shippable badge][shippable-img]][shippable]
 
 [![Join the chat at https://gitter.im/spf-tools/spf-tools][gitter-img]][gitter]
 
@@ -280,5 +279,3 @@ spread the word: Free domains: http://www.eu.org/
 [semaphore]: https://semaphoreci.com/spf-tools/spf-tools
 [gitter-img]: https://badges.gitter.im/Join%20Chat.svg
 [gitter]: https://gitter.im/spf-tools/spf-tools
-[shippable-img]: https://api.shippable.com/projects/5770eda33be4f4faa56ae58a/badge?branch=master
-[shippable]: https://app.shippable.com/projects/5770eda33be4f4faa56ae58a/status/

--- a/shippable.yml
+++ b/shippable.yml
@@ -1,6 +1,0 @@
-language: none
-
-build:
-    ci:
-        - misc/ci-setup.sh
-        - misc/ci-runtest.sh


### PR DESCRIPTION
Shippable was acquired by JFrog

https://jfrog.com/pipelines/
https://jfrog.com/pricing/
http://blog.shippable.com/the-next-step-in-the-evolution-of-shippable-jfrog-pipelines
http://blog.shippable.com/migrating-from-shippable-to-jfrog-pipelines