### PR TITLE
mkblocks: Provide an option to force prefix numbering on the first block.

### DIFF
--- a/mkblocks.sh
+++ b/mkblocks.sh
@@ -43,6 +43,7 @@ header="v=spf1"
 length=257
 strlength=255
 start=1
+forcenumbering=false
 
 usage() {
     cat <<-EOF
@@ -59,6 +60,7 @@ usage() {
 	  -o POLICY                  set default SPF policy
 	  -d DELIM                   set delimiter of output
 	  -s START                   set the numbering start
+	  -f                         force prefix numbing on the first block
 
 	Default values:
 	  HEADER = $header
@@ -69,11 +71,12 @@ usage() {
 	  POLICY = $policy
 	  DELIM  = $delim
 	  START  = $start
+	  FORCENUMBERING = $forcenumbering
 	EOF
     exit 1
 }
 
-while getopts "h:l:L:p:x:o:d:s:-" opt; do
+while getopts "h:l:L:p:x:o:d:s:f-" opt; do
   case $opt in
     h) test -n "$OPTARG" && header=$OPTARG;;
     l) test -n "$OPTARG" && length=$OPTARG;;
@@ -83,6 +86,7 @@ while getopts "h:l:L:p:x:o:d:s:-" opt; do
     o) test -n "$OPTARG" && policy=$OPTARG;;
     d) test -n "$OPTARG" && delim=$OPTARG;;
     s) test -n "$OPTARG" && start=$OPTARG;;
+    f) forcenumbering=true;;
     *) usage;;
   esac
 done
@@ -106,8 +110,11 @@ mysed() {
 
 myout() {
   local mycounter=${3:-'1'}
+  if [ $forcenumbering = true ]; then
+      mycounter=$((mycounter+1))
+  fi
   rrlabel=$1
-  if [ $mycounter -eq 1 ]; then
+  if [ $mycounter -eq 1 ] && [ $forcenumbering = false ]; then
       #first resource label of chain is bare domain
       rrlabel="$domain"
   fi

--- a/mkblocks.sh
+++ b/mkblocks.sh
@@ -60,7 +60,7 @@ usage() {
 	  -o POLICY                  set default SPF policy
 	  -d DELIM                   set delimiter of output
 	  -s START                   set the numbering start
-	  -f                         force prefix numbing on the first block
+	  -f                         force prefix numbering on the first block
 
 	Default values:
 	  HEADER = $header

--- a/tests/mkblocks-help/out
+++ b/tests/mkblocks-help/out
@@ -11,6 +11,7 @@ Available options:
   -o POLICY                  set default SPF policy
   -d DELIM                   set delimiter of output
   -s START                   set the numbering start
+  -f                         force prefix numbing on the first block
 
 Default values:
   HEADER = v=spf1
@@ -21,3 +22,4 @@ Default values:
   POLICY = ~all
   DELIM  = ^
   START  = 1
+  FORCENUMBERING = false

--- a/tests/mkblocks-help/out
+++ b/tests/mkblocks-help/out
@@ -11,7 +11,7 @@ Available options:
   -o POLICY                  set default SPF policy
   -d DELIM                   set delimiter of output
   -s START                   set the numbering start
-  -f                         force prefix numbing on the first block
+  -f                         force prefix numbering on the first block
 
 Default values:
   HEADER = v=spf1


### PR DESCRIPTION
A needed feature for me, so feel it could be useful for others as well.

My reasoning for this is as follows;
The core domain I'm need SPF flattening for is registered to a provider who doesn't provide an API access for record changes.
Therefore, I'd like to reuse a secondary domain I have hosted on another provider (with API access) to host these records.
This secondary domain already has an existing SPF record which I don't want to interfere with.

Understand that there's a few ways around this, like a subdomain prefix or simply transferring the domain to the API provider, but this method is the most suitable at the moment.