### PR TITLE
Fix printf error when record contains macros

### DIFF
--- a/mkblocks.sh
+++ b/mkblocks.sh
@@ -113,7 +113,7 @@ myout() {
   fi
   mystart=$(echo $rrlabel | mysed $((mycounter-1)))
   myrest=$(echo $2 | mysed $((mycounter)))
-  output=$(printf "$header $myrest" | awk "{gsub(/.{$strlength}/,\"&\\\" \\\"\")}1")
+  output=$(printf "%s" "$header $myrest" | awk "{gsub(/.{$strlength}/,\"&\\\" \\\"\")}1")
   echo ${mystart}${delim}\"$output\"
 }
 


### PR DESCRIPTION
When an SPF record contains a macro (such as `%{ir}.%{v}.example.com`), mkblocks.sh fails with: 

```
./mkblocks.sh: line 116: printf: `{': invalid format character
```

This fixes the printf call, adding a simple format argument of `"%s"` so that printf does not try to treat the printed value as a format string.